### PR TITLE
ci: use errata-ai/vale-action for spellchecking

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,5 +1,9 @@
 name: Spellcheck
-on: [pull_request]
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
 
 jobs:
   vale:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,11 @@
+name: Spellcheck
+on: [pull_request]
+
+jobs:
+  vale:
+    name: Spellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: errata-ai/vale-action@v2.1.1
+

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -6,6 +6,16 @@ jobs:
     name: Spellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: errata-ai/vale-action@v2.1.1
+      - name: Checkout
+        uses: actions/checkout@v4
 
+      - name: Spellcheck
+        uses: errata-ai/vale-action@v2.1.1
+        with:
+          version: latest
+          files: all
+          debug: false
+          reporter: github-check # https://github.com/reviewdog/reviewdog#reporters
+          fail_on_error: true
+          level: error
+          filter_mode: added

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,6 @@
+StylesPath = .vale
+MinAlertLevel = suggestion
+Vocab = AspirePress, Technical, Misc
+
+[*.md]
+BasedOnStyles = Vale

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,5 +1,8 @@
+# https://vale.sh/docs/topics/config/
 StylesPath = .vale
 MinAlertLevel = suggestion
+
+# https://vale.sh/docs/topics/vocab/
 Vocab = AspirePress, Technical, Misc
 
 [*.md]

--- a/.vale/config/vocabularies/AspirePress/accept.txt
+++ b/.vale/config/vocabularies/AspirePress/accept.txt
@@ -1,0 +1,3 @@
+AspirePress
+ClassicPress
+WordPress

--- a/.vale/config/vocabularies/AspirePress/reject.txt
+++ b/.vale/config/vocabularies/AspirePress/reject.txt
@@ -1,9 +1,5 @@
-# accept.txt - words considered acceptable spellings
+# reject.txt - words always considered to be spelling errors
 #
 # lines beginning with '#' are ignored.
 # each line is one word or regex, and is case-sensitive.
 # prefix with (?i) to make case-insensitive.
-
-AspirePress
-ClassicPress
-WordPress

--- a/.vale/config/vocabularies/Misc/accept.txt
+++ b/.vale/config/vocabularies/Misc/accept.txt
@@ -1,0 +1,1 @@
+hominem

--- a/.vale/config/vocabularies/Technical/accept.txt
+++ b/.vale/config/vocabularies/Technical/accept.txt
@@ -1,0 +1,3 @@
+(?i)css
+(?i)nginx
+(?i)webpack

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Governance
 
-Governance documentation for AspirePress. You can view this documentation at 
+Governance documentation for AspirePress. You can view this documentation at
 [AspirePress Governance](https://governance.aspirepress.org).


### PR DESCRIPTION
# Pull Request

## What changed?

Adds a CI action to perform spellchecking on all markdown files using Vale.

## Why did it change?

```
ODE TO A SPELL CHECKER
by Jerrold H Zar

Eye halve a spelling check her,
It came with my pea sea.
It plane lee marks four my revue
Miss steaks aye kin knot sea.
Eye ran this poem threw it,
Your sure reel glad two no.
Its vary polished in it’s weigh,
My checker tolled me sew.
A check her is a bless sing;
It freeze yew lodes of thyme.
It helps me right awl stiles two reed,
And aides me when aye rime.
Each frays come posed up on my screen,
Eye trussed too bee a joule;
The checker pours o’er every word
To cheque sum spelling rule.
Bee fore wee rote with checkers
Hour spelling was inn deck line,
Butt now when wee dew have a laps,
Wee are knot maid too wine.
Butt now bee cause my spelling
Is checked with such grate flare,
There are know faults with in my cite,
Of nun eye am a wear.
Now spelling does knot phase me,
It does knot bring a tier;
My pay purrs awl due glad den
With wrapped words fare as hear.
To rite with care is quite a feet
Of witch won should be proud;
And we mussed dew the best wee can
Sew flaws are knot aloud.
That’s why eye brake in two averse
Cuz eye dew want too please.
Sow glad eye yam that aye did bye
This soft wear four pea seas.
```

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

